### PR TITLE
Remove variable renaming

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,28 +4,36 @@ import System.Console.Haskeline
 import Untyped.Evaluator
 import Untyped.Parser
 
-processInput :: String -> String
-processInput input =
+processInput :: EvaluationStrategy -> String -> String
+processInput evalStrat input =
   let parseResult = Untyped.Parser.fullParser input
    in case parseResult of
         Left err -> show err
-        Right t -> reduceTerm t
+        Right t -> reduceTerm evalStrat t
 
-reduceTerm :: Term -> String
-reduceTerm t =
-  case evalBeta t of
+reduceTerm :: EvaluationStrategy -> Term -> String
+reduceTerm evalStrat t =
+  case evalWithStrategy evalStrat t of
     Left err -> show err
     Right t' -> show t'
 
 main :: IO ()
-main = putStrLn "Untyped lambda calculus REPL" >> runInputT defaultSettings loop
+main =
+  putStrLn "Untyped lambda calculus REPL" >>
+  runInputT defaultSettings (loop CallByValue)
   where
-    loop :: InputT IO ()
-    loop = do
+    loop :: EvaluationStrategy -> InputT IO ()
+    loop evalStrat = do
       minput <- getInputLine "> "
       case minput of
         Nothing -> return ()
         Just "quit" -> return ()
+        Just ":cbv" -> do
+          outputStrLn "Switching to call by value evaluation mode"
+          loop CallByValue
+        Just ":beta" -> do
+          outputStrLn "Switching to full beta reduction evaluation mode"
+          loop FullBeta
         Just input -> do
-          outputStrLn $ processInput input
-          loop
+          outputStrLn $ processInput evalStrat input
+          loop evalStrat

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ processInput input =
 
 reduceTerm :: Term -> String
 reduceTerm t =
-  case eval t of
+  case evalBeta t of
     Left err -> show err
     Right t' -> show t'
 

--- a/src/Untyped/Evaluator.hs
+++ b/src/Untyped/Evaluator.hs
@@ -2,24 +2,24 @@ module Untyped.Evaluator where
 
 import Control.Monad ((<=<))
 import Data.List (elemIndex)
-import Data.Maybe (fromMaybe)
 import Untyped.Parser (Term(..))
 
+-- this is not really a "nameless" term, since we are remembering the names in disguise
+-- in order to restore them later, rather than generating arbitrary names
 data NamelessTerm
   = NT_VAR Int
-  | NT_ABS NamelessTerm
+  | NT_ABS String
+           NamelessTerm
   | NT_APP NamelessTerm
            NamelessTerm
   deriving (Eq)
 
 instance Show NamelessTerm where
   show (NT_VAR x) = show x
-  show (NT_ABS t) = "\\" ++ "." ++ show t
+  show (NT_ABS _ t) = "\\" ++ "." ++ show t
   show (NT_APP t1 t2) = "(" ++ show t1 ++ " " ++ show t2 ++ ")"
 
 type Context = [String]
-
-type NameGenerator = [String] -> String
 
 atMay :: [a] -> Int -> Maybe a
 atMay [] _ = Nothing
@@ -40,50 +40,33 @@ removeNames :: Context -> Term -> Either RuntimeError NamelessTerm
 removeNames c (T_VAR s) =
   maybeToEither (UnboundVariable s) $ fmap NT_VAR (elemIndex s c)
 removeNames c (T_APP t1 t2) = NT_APP <$> removeNames c t1 <*> removeNames c t2
-removeNames c (T_ABS (T_VAR s) t) = NT_ABS <$> removeNames (s : c) t
+removeNames c (T_ABS (T_VAR s) t) = NT_ABS s <$> removeNames (s : c) t
 
-restoreNames ::
-     NameGenerator -> Context -> NamelessTerm -> Either RuntimeError Term
-restoreNames _ c (NT_VAR n) =
+restoreNames :: Context -> NamelessTerm -> Either RuntimeError Term
+restoreNames c (NT_VAR n) =
   maybeToEither RestoreNameError $ fmap T_VAR (atMay c n)
-restoreNames ng c (NT_APP t1 t2) =
-  T_APP <$> restoreNames ng c t1 <*> restoreNames ng c t2
-restoreNames ng c (NT_ABS t) =
-  let newName = ng c
-   in T_ABS (T_VAR newName) <$> restoreNames ng (newName : c) t
-
--- FIXME: stops working after 26 names!
-genNewVarName :: NameGenerator
-genNewVarName [] = "a"
-genNewVarName (h:_) =
-  let letters = map (: []) ['a' .. 'z']
-      indexOfLast :: Maybe Int
-      indexOfLast = elemIndex h letters
-      newLetter :: Maybe String
-      newLetter = ((+ 1) <$> indexOfLast) >>= atMay letters
-   in fromMaybe "a" newLetter --FIXME: swallowing error here
+restoreNames c (NT_APP t1 t2) =
+  T_APP <$> restoreNames c t1 <*> restoreNames c t2
+restoreNames c (NT_ABS s t) = T_ABS (T_VAR s) <$> restoreNames (s : c) t
 
 shift :: Int -> Int -> NamelessTerm -> NamelessTerm
 shift d c v@(NT_VAR k)
   | k < c = v
   | otherwise = NT_VAR (k + d)
-shift d c (NT_ABS t) = NT_ABS (shift d (c + 1) t)
+shift d c (NT_ABS s t) = NT_ABS s (shift d (c + 1) t)
 shift d c (NT_APP t1 t2) = NT_APP (shift d c t1) (shift d c t2)
 
 substitution :: Int -> NamelessTerm -> NamelessTerm -> NamelessTerm
 substitution j s v@(NT_VAR k)
   | k == j = s
   | otherwise = v
-substitution j s (NT_ABS t1) = NT_ABS (substitution (j + 1) (shift 1 0 s) t1)
+substitution j s (NT_ABS name t1) =
+  NT_ABS name (substitution (j + 1) (shift 1 0 s) t1)
 substitution j s (NT_APP t1 t2) =
   NT_APP (substitution j s t1) (substitution j s t2)
 
 eval :: Term -> Either RuntimeError Term
-eval = evalWithNameGen genNewVarName
-
-evalWithNameGen :: NameGenerator -> Term -> Either RuntimeError Term
-evalWithNameGen ng =
-  restoreNames ng [] <=< return . evalNameless <=< removeNames []
+eval = restoreNames [] <=< return . evalNameless <=< removeNames []
 
 evalNameless :: NamelessTerm -> NamelessTerm
 evalNameless term =
@@ -93,22 +76,18 @@ evalNameless term =
         else evalNameless newTerm
 
 evalNameless1Step :: NamelessTerm -> NamelessTerm
-evalNameless1Step (NT_APP (NT_ABS t12) v2@(NT_ABS _)) =
+evalNameless1Step (NT_APP (NT_ABS _ t12) v2@(NT_ABS _ _)) =
   let shiftedv2 = shift 1 0 v2
       substituedt12 = substitution 0 shiftedv2 t12
    in shift (-1) 0 substituedt12
-evalNameless1Step (NT_APP v1@(NT_ABS _) t2) = NT_APP v1 (evalNameless1Step t2)
+evalNameless1Step (NT_APP v1@(NT_ABS _ _) t2) = NT_APP v1 (evalNameless1Step t2)
 evalNameless1Step (NT_APP t1 t2) = NT_APP (evalNameless t1) t2
 evalNameless1Step t = t
 
 -- beta evaluation
 -- TODO: refactor this with `Strategy` pattern
 evalBeta :: Term -> Either RuntimeError Term
-evalBeta = evalBetaWithNameGen genNewVarName
-
-evalBetaWithNameGen :: NameGenerator -> Term -> Either RuntimeError Term
-evalBetaWithNameGen ng =
-  restoreNames ng [] <=< return . evalBetaNameless <=< removeNames []
+evalBeta = restoreNames [] <=< return . evalBetaNameless <=< removeNames []
 
 evalBetaNameless :: NamelessTerm -> NamelessTerm
 evalBetaNameless term =
@@ -118,8 +97,9 @@ evalBetaNameless term =
         else evalBetaNameless newTerm
 
 evalBetaNameless1Step :: NamelessTerm -> NamelessTerm
-evalBetaNameless1Step (NT_APP (NT_ABS t12) t2) = substitution 0 t2 t12
+evalBetaNameless1Step (NT_APP (NT_ABS _ t12) t2) = substitution 0 t2 t12
 evalBetaNameless1Step (NT_APP t1 t2) =
   NT_APP (evalBetaNameless1Step t1) (evalBetaNameless1Step t2)
-evalBetaNameless1Step (NT_ABS t) = NT_ABS (evalBetaNameless1Step t)
+evalBetaNameless1Step (NT_ABS varname t) =
+  NT_ABS varname (evalBetaNameless1Step t)
 evalBetaNameless1Step t = t

--- a/src/Untyped/Evaluator.hs
+++ b/src/Untyped/Evaluator.hs
@@ -22,9 +22,10 @@ pickFreshName s l
   | s `notElem` l = s
 pickFreshName s l = g 1 s l
   where
-    g n s l
-      | s ++ show n `elem` l = g (n + 1) s l
-      | otherwise = s ++ show n
+    g :: Int -> String -> [String] -> String
+    g n name existingNames
+      | name ++ show n `elem` existingNames = g (n + 1) name existingNames
+      | otherwise = name ++ show n
 
 substitution :: String -> Term -> Term -> Term
 substitution x s (T_VAR y)
@@ -32,9 +33,9 @@ substitution x s (T_VAR y)
   | otherwise = T_VAR y
 substitution x s (T_APP t1 t2) =
   T_APP (substitution x s t1) (substitution x s t2)
-substitution x s t@(T_ABS (T_VAR y) t1)
+substitution x _ t@(T_ABS (T_VAR y) _)
   | x == y = t
-substitution x s t@(T_ABS (T_VAR y) t1) =
+substitution x s (T_ABS (T_VAR y) t1) =
   let fv = getFreeVars s
    in if y `notElem` fv
         then T_ABS (T_VAR y) (substitution x s t1)
@@ -56,9 +57,9 @@ eval term =
     Left x -> Left (UnboundVariable x)
     Right _ -> Right (actualEval term)
   where
-    actualEval term =
-      let newTerm = eval1Step term
-       in if newTerm == term
+    actualEval t =
+      let newTerm = eval1Step t
+       in if newTerm == t
             then newTerm
             else actualEval newTerm
 
@@ -76,9 +77,9 @@ evalBeta term =
     Left x -> Left (UnboundVariable x)
     Right _ -> Right (actualEval term)
   where
-    actualEval term =
-      let newTerm = evalBeta1Step term
-       in if newTerm == term
+    actualEval t =
+      let newTerm = evalBeta1Step t
+       in if newTerm == t
             then newTerm
             else actualEval newTerm
 

--- a/src/Untyped/Evaluator.hs
+++ b/src/Untyped/Evaluator.hs
@@ -1,119 +1,14 @@
 module Untyped.Evaluator where
 
-import Control.Monad ((<=<))
-import Data.List (elemIndex)
 import Untyped.Parser (Term(..))
-
--- this is not really a "nameless" term, since we are remembering the names in disguise
--- in order to restore them later, rather than generating arbitrary names
-data NamelessTerm
-  = NT_VAR Int
-  | NT_ABS String
-           NamelessTerm
-  | NT_APP NamelessTerm
-           NamelessTerm
-  deriving (Eq)
-
-instance Show NamelessTerm where
-  show (NT_VAR x) = show x
-  show (NT_ABS _ t) = "\\" ++ "." ++ show t
-  show (NT_APP t1 t2) = showL t1 ++ " " ++ showR t2
-    where
-      showL (NT_VAR x) = show x
-      showL t@(NT_ABS _ _) = "(" ++ show t ++ ")"
-      showL t@(NT_APP _ _) = show t
-      showR (NT_VAR x) = show x
-      showR t@(NT_ABS _ _) = show t
-      showR t@(NT_APP _ _) = "(" ++ show t ++ ")"
-
-type Context = [String]
-
-atMay :: [a] -> Int -> Maybe a
-atMay [] _ = Nothing
-atMay (h:_) 0 = Just h
-atMay (_:t) n = atMay t (n - 1)
-
-maybeToEither :: b -> Maybe a -> Either b a
-maybeToEither b Nothing = Left b
-maybeToEither _ (Just a) = Right a
 
 data RuntimeError
   = ParsingError -- FIXME:only here for tests, remove this
   | UnboundVariable String
-  | RestoreNameError
   deriving (Eq, Show)
 
-removeNames :: Context -> Term -> Either RuntimeError NamelessTerm
-removeNames c (T_VAR s) =
-  maybeToEither (UnboundVariable s) $ fmap NT_VAR (elemIndex s c)
-removeNames c (T_APP t1 t2) = NT_APP <$> removeNames c t1 <*> removeNames c t2
-removeNames c (T_ABS (T_VAR s) t) = NT_ABS s <$> removeNames (s : c) t
-
-restoreNames :: Context -> NamelessTerm -> Either RuntimeError Term
-restoreNames c (NT_VAR n) =
-  maybeToEither RestoreNameError $ fmap T_VAR (atMay c n)
-restoreNames c (NT_APP t1 t2) =
-  T_APP <$> restoreNames c t1 <*> restoreNames c t2
-restoreNames c (NT_ABS s t) = T_ABS (T_VAR s) <$> restoreNames (s : c) t
-
-shift :: Int -> Int -> NamelessTerm -> NamelessTerm
-shift d c v@(NT_VAR k)
-  | k < c = v
-  | otherwise = NT_VAR (k + d)
-shift d c (NT_ABS s t) = NT_ABS s (shift d (c + 1) t)
-shift d c (NT_APP t1 t2) = NT_APP (shift d c t1) (shift d c t2)
-
-substitution :: Int -> NamelessTerm -> NamelessTerm -> NamelessTerm
-substitution j s v@(NT_VAR k)
-  | k == j = s
-  | otherwise = v
-substitution j s (NT_ABS name t1) =
-  NT_ABS name (substitution (j + 1) (shift 1 0 s) t1)
-substitution j s (NT_APP t1 t2) =
-  NT_APP (substitution j s t1) (substitution j s t2)
-
-eval :: Term -> Either RuntimeError Term
-eval = restoreNames [] <=< return . evalNameless <=< removeNames []
-
-evalNameless :: NamelessTerm -> NamelessTerm
-evalNameless term =
-  let newTerm = evalNameless1Step term
-   in if newTerm == term
-        then newTerm
-        else evalNameless newTerm
-
-evalNameless1Step :: NamelessTerm -> NamelessTerm
-evalNameless1Step (NT_APP (NT_ABS _ t12) v2@(NT_ABS _ _)) =
-  let shiftedv2 = shift 1 0 v2
-      substituedt12 = substitution 0 shiftedv2 t12
-   in shift (-1) 0 substituedt12
-evalNameless1Step (NT_APP v1@(NT_ABS _ _) t2) = NT_APP v1 (evalNameless1Step t2)
-evalNameless1Step (NT_APP t1 t2) = NT_APP (evalNameless t1) t2
-evalNameless1Step t = t
-
--- beta evaluation
--- TODO: refactor this with `Strategy` pattern
-evalBeta :: Term -> Either RuntimeError Term
-evalBeta = restoreNames [] <=< return . evalBetaNameless <=< removeNames []
-
-evalBetaNameless :: NamelessTerm -> NamelessTerm
-evalBetaNameless term =
-  let newTerm = evalBetaNameless1Step term
-   in if newTerm == term
-        then newTerm
-        else evalBetaNameless newTerm
-
-evalBetaNameless1Step :: NamelessTerm -> NamelessTerm
-evalBetaNameless1Step (NT_APP (NT_ABS _ t12) t2) = substitution 0 t2 t12
-evalBetaNameless1Step (NT_APP t1 t2) =
-  NT_APP (evalBetaNameless1Step t1) (evalBetaNameless1Step t2)
-evalBetaNameless1Step (NT_ABS varname t) =
-  NT_ABS varname (evalBetaNameless1Step t)
-evalBetaNameless1Step t = t
-
--- experimental
-freeVars :: Term -> [String]
-freeVars = g []
+getFreeVars :: Term -> [String]
+getFreeVars = g []
   where
     g :: [String] -> Term -> [String]
     g boundVars (T_VAR s)
@@ -131,34 +26,64 @@ pickFreshName s l = g 1 s l
       | s ++ show n `elem` l = g (n + 1) s l
       | otherwise = s ++ show n
 
-substitution' :: String -> Term -> Term -> Term
-substitution' x s (T_VAR y)
+substitution :: String -> Term -> Term -> Term
+substitution x s (T_VAR y)
   | x == y = s
   | otherwise = T_VAR y
-substitution' x s (T_APP t1 t2) =
-  T_APP (substitution' x s t1) (substitution' x s t2)
-substitution' x s t@(T_ABS (T_VAR y) t1)
+substitution x s (T_APP t1 t2) =
+  T_APP (substitution x s t1) (substitution x s t2)
+substitution x s t@(T_ABS (T_VAR y) t1)
   | x == y = t
-substitution' x s t@(T_ABS (T_VAR y) t1) =
-  let fv = freeVars s
+substitution x s t@(T_ABS (T_VAR y) t1) =
+  let fv = getFreeVars s
    in if y `notElem` fv
-        then T_ABS (T_VAR y) (substitution' x s t1)
-        else T_ABS (T_VAR (pickFreshName y fv)) (substitution' x s t1)
+        then T_ABS (T_VAR y) (substitution x s t1)
+        else T_ABS (T_VAR (pickFreshName y fv)) (substitution x s t1)
 
-evalBeta' :: Term -> Either RuntimeError Term
-evalBeta' term = do
-  newTerm <- evalBeta1Step' [] term -- this is suspicious
-  if newTerm == term
-    then return newTerm
-    else evalBeta' newTerm
+checkVarsAreBound :: Term -> Either String ()
+checkVarsAreBound = g []
+  where
+    g :: [String] -> Term -> Either String ()
+    g boundVars (T_VAR x)
+      | x `elem` boundVars = Right ()
+      | otherwise = Left x
+    g boundVars (T_APP t1 t2) = g boundVars t1 >> g boundVars t2
+    g boundVars (T_ABS (T_VAR x) t) = g (x : boundVars) t
 
-evalBeta1Step' :: Context -> Term -> Either RuntimeError Term
-evalBeta1Step' c (T_APP (T_ABS (T_VAR x) t12) t2) =
-  Right (substitution' x t2 t12)
-evalBeta1Step' c (T_APP t1 t2) =
-  T_APP <$> evalBeta1Step' c t1 <*> evalBeta1Step' c t2
-evalBeta1Step' c (T_ABS (T_VAR x) t) =
-  T_ABS (T_VAR x) <$> evalBeta1Step' (x : c) t
-evalBeta1Step' c t@(T_VAR x)
-  | x `elem` c = Right t
-  | otherwise = Left (UnboundVariable x)
+eval :: Term -> Either RuntimeError Term
+eval term =
+  case checkVarsAreBound term of
+    Left x -> Left (UnboundVariable x)
+    Right _ -> Right (actualEval term)
+  where
+    actualEval term =
+      let newTerm = eval1Step term
+       in if newTerm == term
+            then newTerm
+            else actualEval newTerm
+
+eval1Step :: Term -> Term
+eval1Step (T_APP (T_ABS (T_VAR x) t12) v2@(T_ABS _ _)) = substitution x v2 t12
+eval1Step (T_APP v1@(T_ABS _ _) t2) = T_APP v1 (eval1Step t2)
+eval1Step (T_APP t1 t2) = T_APP (eval1Step t1) t2
+eval1Step t = t
+
+-- beta evaluation
+-- TODO: refactor this with `Strategy` pattern
+evalBeta :: Term -> Either RuntimeError Term
+evalBeta term =
+  case checkVarsAreBound term of
+    Left x -> Left (UnboundVariable x)
+    Right _ -> Right (actualEval term)
+  where
+    actualEval term =
+      let newTerm = evalBeta1Step term
+       in if newTerm == term
+            then newTerm
+            else actualEval newTerm
+
+evalBeta1Step :: Term -> Term
+evalBeta1Step (T_APP (T_ABS (T_VAR x) t12) t2) = substitution x t2 t12
+evalBeta1Step (T_APP t1 t2) = T_APP (evalBeta1Step t1) (evalBeta1Step t2)
+evalBeta1Step (T_ABS (T_VAR x) t) = T_ABS (T_VAR x) (evalBeta1Step t)
+evalBeta1Step t = t

--- a/src/Untyped/Evaluator.hs
+++ b/src/Untyped/Evaluator.hs
@@ -17,7 +17,14 @@ data NamelessTerm
 instance Show NamelessTerm where
   show (NT_VAR x) = show x
   show (NT_ABS _ t) = "\\" ++ "." ++ show t
-  show (NT_APP t1 t2) = "(" ++ show t1 ++ " " ++ show t2 ++ ")"
+  show (NT_APP t1 t2) = showL t1 ++ " " ++ showR t2
+    where
+      showL (NT_VAR x) = show x
+      showL t@(NT_ABS _ _) = "(" ++ show t ++ ")"
+      showL t@(NT_APP _ _) = show t
+      showR (NT_VAR x) = show x
+      showR t@(NT_ABS _ _) = show t
+      showR t@(NT_APP _ _) = "(" ++ show t ++ ")"
 
 type Context = [String]
 

--- a/src/Untyped/Parser.hs
+++ b/src/Untyped/Parser.hs
@@ -41,6 +41,7 @@ lexer :: String -> Either ParseError [Token]
 lexer input = parse (parseTokens <* eof) "lexing error" input
 
 -- parse
+-- TODO: T_ABS should be String -> Term -> Term
 data Term
   = T_VAR String
   | T_ABS Term

--- a/test/UntypedSpec.hs
+++ b/test/UntypedSpec.hs
@@ -87,36 +87,36 @@ spec = do
         Right "\\t.\\f.t"
     it "evaluates succ zero to a term equivalent to one" $ do
       fmap show (parseThenEval "(\\c.\\s.\\z.s (c s z)) \\s.\\z.z") `shouldBe`
-        Right "\\a.\\b.a ((\\c.\\d.d) a b)"
+        Right "\\s.\\z.s ((\\s.\\z.z) s z)"
     it "prevents variable capture" $ do
-      fmap show (parseThenEval "\\x.(\\x.x) x") `shouldBe` Right "\\a.(\\b.b) a"
+      fmap show (parseThenEval "\\x.(\\x.x) x") `shouldBe` Right "\\x.(\\x.x) x"
     it "prevents variable capture v2" $ do
       fmap show (parseThenEval "(\\y.\\x.x y) \\x.x") `shouldBe`
-        Right "\\a.a \\b.b"
+        Right "\\x.x \\x.x"
     it "evaluates nested expression" $ do
       fmap show (parseThenEval "(\\x.x) ((\\x.x) (\\z. (\\x.x) z))") `shouldBe`
-        Right "\\a.(\\b.b) a"
+        Right "\\z.(\\x.x) z"
     it "fails on unbound variable" $ do
       fmap show (parseThenEval "x") `shouldBe` Left (UnboundVariable "x")
     it "fails on unbound variable inside simple application" $ do
       fmap show (parseThenEval "\\x.x y") `shouldBe` Left (UnboundVariable "y")
   describe "Untyped Beta evaluation" $ do
     it "fully reduces \\x. (\\y.y) x" $ do
-      fmap show (parseThenEvalBeta "\\x. (\\y.y) x") `shouldBe` Right "\\a.a"
+      fmap show (parseThenEvalBeta "\\x. (\\y.y) x") `shouldBe` Right "\\x.x"
     it "fully reduces \\x. (\\x.x) x" $ do
-      fmap show (parseThenEvalBeta "\\x. (\\x.x) x") `shouldBe` Right "\\a.a"
+      fmap show (parseThenEvalBeta "\\x. (\\x.x) x") `shouldBe` Right "\\x.x"
     it "prevents variable capture" $ do
       fmap show (parseThenEvalBeta "(\\y.\\x.x y) \\x.x") `shouldBe`
-        Right "\\a.a \\b.b"
+        Right "\\x.x \\x.x"
     it "prevents variable capture v2" $ do
       fmap show (parseThenEvalBeta "(\\y.\\x.x y) \\x.x") `shouldBe`
-        Right "\\a.a \\b.b"
+        Right "\\x.x \\x.x"
     it "prevents variable capture v3" $ do
       fmap show (parseThenEvalBeta "\\z.((\\x.\\z.x) z)") `shouldBe`
         Right "\\a.\\b.a"
     it "fully reduces nested expression" $ do
       fmap show (parseThenEvalBeta "(\\x.x) ((\\x.x) (\\z. (\\x.x) z))") `shouldBe`
-        Right "\\a.a"
+        Right "\\z.z"
     it "fully reduces succ zero to one" $ do
       fmap show (parseThenEvalBeta "(\\c.\\s.\\z.s (c s z)) \\s.\\z.z") `shouldBe`
-        Right "\\a.\\b.a b"
+        Right "\\s.\\z.s z"

--- a/test/UntypedSpec.hs
+++ b/test/UntypedSpec.hs
@@ -111,6 +111,12 @@ spec = do
     it "preserves bound variable" $ do
       fmap show (parseThenEvalBeta "\\y.(\\x.\\x.x) y") `shouldBe`
         Right "\\y.\\x.x"
+    it "2 + 3 = 5" $ do
+      fmap
+        show
+        (parseThenEvalBeta
+           "(\\m.\\n.\\s.\\z.m s (n s z)) (\\s.\\z.s (s z)) (\\s.\\z.s (s (s z)))") `shouldBe`
+        Right "\\s.\\z.s (s (s (s (s z))))"
     it "fails on unbound variable" $ do
       fmap show (parseThenEvalBeta "x") `shouldBe` Left (UnboundVariable "x")
     it "fails on unbound variable inside simple application" $ do

--- a/test/UntypedSpec.hs
+++ b/test/UntypedSpec.hs
@@ -93,9 +93,15 @@ spec = do
     it "prevents variable capture v2" $ do
       fmap show (parseThenEval "(\\y.\\x.x y) \\x.x") `shouldBe`
         Right "\\x.x \\x.x"
+    it "prevents variable capture v3" $ do
+      fmap show (parseThenEval "(\\z.((\\x.\\z.x) z)) \\x.\\y.x y") `shouldBe`
+        Right "\\z'.\\x.\\y.x y"
     it "evaluates nested expression" $ do
       fmap show (parseThenEval "(\\x.x) ((\\x.x) (\\z. (\\x.x) z))") `shouldBe`
         Right "\\z.(\\x.x) z"
+    it "preserves bound variable" $ do
+      fmap show (parseThenEval "(\\y.(\\x.\\x.x) y) \\s.\\w.\\z.s w z") `shouldBe`
+        Right "\\x.x"
     it "fails on unbound variable" $ do
       fmap show (parseThenEval "x") `shouldBe` Left (UnboundVariable "x")
     it "fails on unbound variable inside simple application" $ do
@@ -113,10 +119,13 @@ spec = do
         Right "\\x.x \\x.x"
     it "prevents variable capture v3" $ do
       fmap show (parseThenEvalBeta "\\z.((\\x.\\z.x) z)") `shouldBe`
-        Right "\\a.\\b.a"
+        Right "\\z.\\z'.z"
     it "fully reduces nested expression" $ do
       fmap show (parseThenEvalBeta "(\\x.x) ((\\x.x) (\\z. (\\x.x) z))") `shouldBe`
         Right "\\z.z"
     it "fully reduces succ zero to one" $ do
       fmap show (parseThenEvalBeta "(\\c.\\s.\\z.s (c s z)) \\s.\\z.z") `shouldBe`
         Right "\\s.\\z.s z"
+    it "preserves bound variable" $ do
+      fmap show (parseThenEvalBeta "\\y.(\\x.\\x.x) y") `shouldBe`
+        Right "\\y.\\x.x"

--- a/test/UntypedSpec.hs
+++ b/test/UntypedSpec.hs
@@ -13,7 +13,7 @@ parseThenEval input = first (const ParsingError) (fullParser input) >>= eval
 
 parseThenEvalBeta :: String -> Either RuntimeError Term
 parseThenEvalBeta input =
-  first (const ParsingError) (fullParser input) >>= evalBeta'
+  first (const ParsingError) (fullParser input) >>= evalBeta
 
 spec :: Spec
 spec = do
@@ -48,30 +48,6 @@ spec = do
       isLeft (fullParser "\\x y.x") `shouldBe` True
     it "fails when given x.x" $ do isLeft (fullParser "x.x") `shouldBe` True
     it "fails when unknown token" $ do isLeft (fullParser "x,x") `shouldBe` True
-  describe "Untyped: convert to nameless terms" $ do
-    it "converts simple variable" $ do
-      removeNames ["x"] (T_VAR "x") `shouldBe` Right (NT_VAR 0)
-    it "converts simple application" $ do
-      removeNames ["x", "y"] (T_APP (T_VAR "x") (T_VAR "y")) `shouldBe`
-        Right (NT_APP (NT_VAR 0) (NT_VAR 1))
-    it "converts simple abstraction" $ do
-      removeNames [] (T_ABS (T_VAR "x") (T_VAR "x")) `shouldBe`
-        Right (NT_ABS "x" (NT_VAR 0))
-    it "converts abstraction with free variable" $ do
-      removeNames ["y"] (T_ABS (T_VAR "x") (T_APP (T_VAR "x") (T_VAR "y"))) `shouldBe`
-        Right (NT_ABS "x" (NT_APP (NT_VAR 0) (NT_VAR 1)))
-  describe "Untyped: convert to named terms" $ do
-    it "renames simple variable" $ do
-      restoreNames ["x"] (NT_VAR 0) `shouldBe` Right (T_VAR "x")
-    it "renames simple application" $ do
-      restoreNames ["x", "y"] (NT_APP (NT_VAR 0) (NT_VAR 1)) `shouldBe`
-        Right (T_APP (T_VAR "x") (T_VAR "y"))
-    it "renames simple abstraction" $ do
-      restoreNames [] (NT_ABS "a" (NT_VAR 0)) `shouldBe`
-        Right (T_ABS (T_VAR "a") (T_VAR "a"))
-    it "renames abstraction with free variable" $ do
-      restoreNames ["a"] (NT_ABS "b" (NT_APP (NT_VAR 0) (NT_VAR 1))) `shouldBe`
-        Right (T_ABS (T_VAR "b") (T_APP (T_VAR "b") (T_VAR "a")))
   describe "Untyped Parsing + Evaluating" $ do
     it "evaluates identity" $ do
       fmap show (parseThenEval "\\x.x") `shouldBe` Right "\\x.x"
@@ -95,7 +71,7 @@ spec = do
         Right "\\x.x \\x.x"
     it "prevents variable capture v3" $ do
       fmap show (parseThenEval "(\\z.((\\x.\\z.x) z)) \\x.\\y.x y") `shouldBe`
-        Right "\\z'.\\x.\\y.x y"
+        Right "\\z.\\x.\\y.x y"
     it "evaluates nested expression" $ do
       fmap show (parseThenEval "(\\x.x) ((\\x.x) (\\z. (\\x.x) z))") `shouldBe`
         Right "\\z.(\\x.x) z"


### PR DESCRIPTION
## What ?

* Keep original variable names when possible. Eg `\x.x` will evaluate to `\x.x` instead of `\a.a`
* Use strategy pattern for implementing evaluation strategies (call by value and full beta reduction).
* Add possibility to switch evaluation strategies in the REPL.

## How ?

* Get rid of De Bruijn indices. Instead, prevent variable capture by renaming terms when necessary.