### PR TITLE
fix a bug in variable capture avoidance.

### DIFF
--- a/src/Untyped/Evaluator.hs
+++ b/src/Untyped/Evaluator.hs
@@ -49,7 +49,9 @@ substitution x s (T_ABS (T_VAR y) t1) =
   let fv = getFreeVars s
    in if y `notElem` fv
         then T_ABS (T_VAR y) (substitution x s t1)
-        else T_ABS (T_VAR (pickFreshName y fv)) (substitution x s t1)
+        else let freshName = pickFreshName y fv
+                 t1' = substitution y (T_VAR freshName) t1
+              in T_ABS (T_VAR freshName) (substitution x s t1')
 
 checkVarsAreBound :: Context -> Term -> Either String ()
 checkVarsAreBound c = g (Map.keys c)

--- a/test/UntypedSpec.hs
+++ b/test/UntypedSpec.hs
@@ -108,6 +108,9 @@ spec = do
     it "prevents variable capture v4" $ do
       fmap show (parseThenEvalBeta "\\z1.\\z.((\\x.\\z.x) (z z1))") `shouldBe`
         Right "\\z1.\\z.\\z2.z z1"
+    it "prevents variable capture v5" $ do
+      fmap show (parseThenEvalBeta "(\\s.\\z.s z) (\\s.\\z.s z)") `shouldBe`
+        Right "\\z.\\z1.z z1"
     it "fully reduces complex expression" $ do
       fmap show (parseThenEvalBeta "\\z1.\\z.((\\x.\\z.x) z z1)") `shouldBe`
         Right "\\z1.\\z.z"


### PR DESCRIPTION
The bug was that when picking a fresh name during substitution, I forgot
to update the body of the function undergoing substitution to account
for the fresh name.